### PR TITLE
Parse mod ids too

### DIFF
--- a/litezip/contrib/pytest/data/invalid_litezip/mux/index.cnxml
+++ b/litezip/contrib/pytest/data/invalid_litezip/mux/index.cnxml
@@ -7,7 +7,7 @@
        Changes to the metadata section in the source will not be saved. -->
   <md:repository>http://cnx.org/content</md:repository>
   <md:content-url>http://cnx.org/content/m42304/latest</md:content-url>
-  <md:content-id>m42304</md:content-id>
+  <md:content-id>mux</md:content-id>
   <md:title>Lab 1-1: 4-Bit Mux and all NAND/NOR Mux</md:title>
   <md:version>1.3</md:version>
   <md:created>2012/01/19 22:11:40 -0600</md:created>

--- a/litezip/main.py
+++ b/litezip/main.py
@@ -40,7 +40,7 @@ COLLECTION_NSMAP = {
 }
 
 
-def _parse_collection_id(elm_tree):
+def _parse_document_id(elm_tree):
     """Given the parsed xml to an `ElementTree`,
     parse the id from the content.
 
@@ -64,11 +64,11 @@ def parse_module(path):
     a module directory.
 
     """
-    id = path.name
     file = path / MODULE_FILENAME
 
     if not file.exists():
         raise MissingFile(file)
+    id = _parse_document_id(etree.parse(file.open()))
 
     excludes = [
         lambda filepath: filepath.name == MODULE_FILENAME,
@@ -86,7 +86,7 @@ def parse_collection(path):
     file = path / COLLECTION_FILENAME
     if not file.exists():
         raise MissingFile(file)
-    id = _parse_collection_id(etree.parse(file.open()))
+    id = _parse_document_id(etree.parse(file.open()))
 
     excludes = [
         lambda filepath: filepath.name == COLLECTION_FILENAME,


### PR DESCRIPTION
don't depend on the dirname