### PR TITLE
latest flake8 warnings - fixup

### DIFF
--- a/litezip/validate.py
+++ b/litezip/validate.py
@@ -15,7 +15,7 @@ __all__ = (
 )
 
 
-VALID_ID_REGEX = re.compile("^(col\d{5,}\d*|m\d{4,}|m?NEW\d{,2})$")
+VALID_ID_REGEX = re.compile(r"^(col\d{5,}\d*|m\d{4,}|m?NEW\d{,2})$")
 
 
 def is_valid_identifier(id):

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,5 +18,8 @@ exclude =
     # Ignore '... import *' issues, because these have valid `__all__` declarations.
     litezip/__init__.py,
     *.egg,
-    .state
+    .state,
+    # Not our code - can the giant python code string be made raw?
+    versioneer.py 
 select = E,W,F,N
+ignore = W504


### PR DESCRIPTION
This handles ignoring W504 (since we don't ignore W503), fixes invalid escapes in a regex pattern,
as well as ignoring versioneer.py wholesale (not our code)